### PR TITLE
Fix I2C initialization

### DIFF
--- a/Arduino/src/FT62XXTouchScreen.h
+++ b/Arduino/src/FT62XXTouchScreen.h
@@ -36,7 +36,8 @@
       }
       
       bool begin() {
-        Wire.begin(m_sda, m_scl);
+        Wire.setPins(m_sda, m_scl);
+        Wire.begin();
         #ifdef TOUCHSCREEN_DEBUG
           Serial.print("Vend ID: 0x");
           Serial.println(readByteFromTouch(FT62XX_REG_VENDID), HEX);

--- a/Arduino_lvgl/src/FT62XXTouchScreen.h
+++ b/Arduino_lvgl/src/FT62XXTouchScreen.h
@@ -36,7 +36,8 @@
       }
       
       bool begin() {
-        Wire.begin(m_sda, m_scl);
+        Wire.setPins(m_sda, m_scl);
+        Wire.begin();
         #ifdef TOUCHSCREEN_DEBUG
           Serial.print("Vend ID: 0x");
           Serial.println(readByteFromTouch(FT62XX_REG_VENDID), HEX);


### PR DESCRIPTION
There are two prototypes for Wire.begin():
```cpp
   bool begin(int sda=-1, int scl=-1, uint32_t frequency=0); // returns true, if successful init of i2c bus
   bool begin(uint8_t slaveAddr, int sda=-1, int scl=-1, uint32_t frequency=0);
```

The problem is that if we call Wire.begin(m_sda, m_scl) then the second (I2C slave) constructor is called (at least this was my case).
If we set pins expicitly and then call Wire.begin() without parameters then there is no ambiguity, the first constructor will be called.